### PR TITLE
Support Babelify (and other transforms) running 1st

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ With browserify:
 ```
 npm install -D browserify
 
-browserify -p cmify/plugin src/index.js
+browserify -p cmify/plugin -t cmify/transform src/index.js
 ```
 
 With hot module reloading:
@@ -34,8 +34,18 @@ With hot module reloading:
 ```
 npm install -D watchify browserify-hmr
 
-watchify -p browserify-hmr -p cmify/plugin src/index.js -o dist/index.js
+watchify -p browserify-hmr -p cmify/plugin -t cmify/transform src/index.js -o dist/index.js
 ```
+
+With babelify:
+
+```
+npm install -D babelify
+
+browserify -p cmify/plugin -t babelify -t cmify/transform src/index.js
+```
+
+_Note: Order of transformations is important; we must babelify before cmify._
 
 How to add postcss plugins
 ----

--- a/create-css-module-source.js
+++ b/create-css-module-source.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const cmify = require('./index')
+
+function createCssModuleSource (filename) {
+  const tokens = cmify.load(filename)
+
+  // make sure all dependencies are added to browserify's tree
+  const output = tokens._deps.map(function (f) {
+    return 'require("' + f + '")'
+  })
+
+  // export the css module's tokens
+  output.push(`/** last updated: ${Date.now()} **/`)
+  output.push(`module.exports=${JSON.stringify(tokens)}`)
+  return output.join('\n')
+}
+
+module.exports = createCssModuleSource

--- a/plugin.js
+++ b/plugin.js
@@ -2,8 +2,8 @@
 
 const cmify = require('./index')
 const through = require('through2')
-const falafel = require('falafel')
 const str = require('string-to-stream')
+const createCssModuleSource = require('./create-css-module-source')
 
 function createCmStream () {
   // fake module
@@ -23,76 +23,6 @@ cmify.getAllCss = function () { return ${JSON.stringify(cmify.getAllCss())} }
 module.exports = cmify`
 }
 
-function createCssModuleSource (filename) {
-  const tokens = cmify.load(filename)
-
-  // make sure all dependencies are added to browserify's tree
-  const output = tokens._deps.map(function (f) {
-    return 'require("' + f + '")'
-  })
-
-  // export the css module's tokens
-  output.push(`/** last updated: ${Date.now()} **/`)
-  output.push(`module.exports=${JSON.stringify(tokens)}`)
-  return output.join('\n')
-}
-
-function cmifyTransform (filename) {
-  const bufs = []
-  let cmifyName = null
-
-  const stream = through(write, end)
-  return stream
-
-  // ----
-
-  function write (buf, enc, next) {
-    bufs.push(buf)
-    next()
-  }
-
-  function end (done) {
-    const src = Buffer.concat(bufs).toString('utf8')
-
-    // handle css files
-    if (/\.css$/.test(filename)) {
-      try {
-        this.push(createCssModuleSource(filename))
-      }
-      catch (err) {
-        this.emit("error", err);
-      }
-    } else {
-      const ast = falafel(src, { ecmaVersion: 6 }, walk)
-      this.push(ast.toString())
-    }
-
-    this.push(null)
-    done()
-  }
-
-  function walk (node) {
-    // find `require('cmify')` and record the name it's bound to
-    if (node.type === 'CallExpression' &&
-        node.callee && node.callee.name === 'require' &&
-        node.arguments.length === 1 &&
-        node.arguments[0].value === 'cmify') {
-      cmifyName = node.parent.id.name
-      return
-    }
-
-    // find places where `cmify.load(...)` is called
-    if (node.type === 'CallExpression' &&
-        node.callee && node.callee.type === 'MemberExpression' &&
-        node.callee.object.name === cmifyName &&
-        node.callee.property.name === 'load'
-       ) {
-      // rewrite as `require`, so it gets included in the dependency tree
-      node.update(`require(${node.arguments[0].raw})`)
-    }
-  }
-}
-
 function cmifyPlugin (b, opts) {
   opts = opts || {}
 
@@ -104,8 +34,6 @@ function cmifyPlugin (b, opts) {
   // register a fake cmify module for the browser
   const cmStream = createCmStream()
   b.require(cmStream, { expose: cmStream.id })
-
-  b.transform(cmifyTransform)
 
   b.on('reset', reset)
   reset()

--- a/transform.js
+++ b/transform.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const falafel = require('falafel')
+const through = require('through2')
+const createCssModuleSource = require('./create-css-module-source')
+
+function cmifyTransform (filename) {
+  const bufs = []
+  let cmifyName = null
+
+  const stream = through(write, end)
+  return stream
+
+  // ----
+
+  function write (buf, enc, next) {
+    bufs.push(buf)
+    next()
+  }
+
+  function end (done) {
+    const src = Buffer.concat(bufs).toString('utf8')
+
+    // handle css files
+    if (/\.css$/.test(filename)) {
+      try {
+        this.push(createCssModuleSource(filename))
+      }
+      catch (err) {
+        this.emit("error", err);
+      }
+    } else {
+      const ast = falafel(src, { ecmaVersion: 6 }, walk)
+      this.push(ast.toString())
+    }
+
+    this.push(null)
+    done()
+  }
+
+  function walk (node) {
+    // find `require('cmify')` and record the name it's bound to
+    if (node.type === 'CallExpression' &&
+        node.callee && node.callee.name === 'require' &&
+        node.arguments.length === 1 &&
+        node.arguments[0].value === 'cmify') {
+      cmifyName = node.parent.id.name
+      return
+    }
+
+    // find places where `cmify.load(...)` is called
+    if (node.type === 'CallExpression' &&
+        node.callee && node.callee.type === 'MemberExpression' &&
+        node.callee.object.name === cmifyName &&
+        node.callee.property.name === 'load'
+       ) {
+      // rewrite as `require`, so it gets included in the dependency tree
+      node.update(`require(${node.arguments[0].raw})`)
+    }
+  }
+}
+
+module.exports = cmifyTransform


### PR DESCRIPTION
## The problem

The crux of it is, this wouldn't work:

```
browserify -p cmify/plugin -t babelify index.js -o out.js
```

Because cmify couldn't handle the ES6 code (plugins are run before transforms)
## The fix

With this change, I exposed the ordering, so we can do:

```
browserify -p cmify/plugin -t babelify -t cmify/transform index.js -o out.js
```

Which runs babelify first, then cmify on the transformed code
## Why?

Falafel uses acorn, which fails to handle ES6 import/export.
By running the cmify transform after babelify, Falafel (acorn) handle the
transformed code just fine.
## Other benefits

This will also allow other transforms to take place before cmify replaces the
loads (such as rewriting paths, running envify, etc, if necessary).
## Notes

Note that I couldn't find a nice way to combine the plugin and transform into one due to the way the plugins are always hooked in before transforms are executed.
