### PR TITLE
Style entry points

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function parseCss (css, filename, visited) {
   function fetch (_to, from) {
     const to = _to.replace(/^["']|["']$/g, '')
     const filename = /\w/i.test(to[0])
-          ? resolve.sync(to)
+          ? resolve.sync(to, {packageFilter: mapStyleEntry})
           : path.resolve(path.dirname(from), to)
 
     const css = fs.readFileSync(filename, 'utf8')
@@ -64,6 +64,11 @@ function parseCss (css, filename, visited) {
     tokens: tokens,
     css: lazyResult.root.toString()
   }
+}
+
+function mapStyleEntry (pkg) {
+  if (!pkg.main && pkg.style) { pkg.main = pkg.style }
+  return pkg
 }
 
 function getResultById (id) {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function parseCss (css, filename, visited) {
   function fetch (_to, from) {
     const to = _to.replace(/^["']|["']$/g, '')
     const filename = /\w/i.test(to[0])
-          ? resolve(to)
+          ? resolve.sync(to)
           : path.resolve(path.dirname(from), to)
 
     const css = fs.readFileSync(filename, 'utf8')

--- a/package.json
+++ b/package.json
@@ -32,5 +32,16 @@
     "standard": "^8.0.0",
     "tap-diff": "^0.1.1",
     "tape": "^4.5.1"
-  }
+  },
+  "directories": {
+    "test": "tests"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/davidmarkclements/cmify.git"
+  },
+  "bugs": {
+    "url": "https://github.com/davidmarkclements/cmify/issues"
+  },
+  "homepage": "https://github.com/davidmarkclements/cmify#readme"
 }


### PR DESCRIPTION
alt. to #9  - allows a package.json to have a `style` field instead of a `main` field to specify the entry point (convention that's followed in the likes of [tachyons](http://tachyons.io))
